### PR TITLE
metadata: Add support for 3.8

### DIFF
--- a/metadata.json.in
+++ b/metadata.json.in
@@ -1,5 +1,5 @@
 {
-  "shell-version": [ "3.10", "3.12" ],
+  "shell-version": [ "3.8", "3.10", "3.12" ],
   "uuid": "@UUID@",
   "name": "@NAME@",
   "description": "Replace the digits with words in the clock",


### PR DESCRIPTION
Tested on CentOS 7
